### PR TITLE
Enable RTCM SD logging with daily rotation

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -11,7 +11,9 @@ idf_component_register(SRCS "main.c"
 		"web_server.c"
 		"wifi.c"
 		"interface/ntrip_server.c"
-		"interface/ntrip_server_2.c"
+                "interface/ntrip_server_2.c"
+
+                "sd_logger.c"
 
 		"protocol/nmea.c"
         INCLUDE_DIRS "include")

--- a/main/config.c
+++ b/main/config.c
@@ -161,6 +161,10 @@ const config_item_t CONFIG_ITEMS[] = {
                 .type = CONFIG_ITEM_TYPE_STRING,
                 .secret = true,
                 .def.str = ""
+        }, {
+                .key = KEY_CONFIG_SD_LOG_ACTIVE,
+                .type = CONFIG_ITEM_TYPE_BOOL,
+                .def.bool1 = false
         },
 
         // UART

--- a/main/include/config.h
+++ b/main/include/config.h
@@ -94,6 +94,9 @@ typedef struct config_item {
 #define KEY_CONFIG_NTRIP_CLIENT_USERNAME "ntr_cli_user"
 #define KEY_CONFIG_NTRIP_CLIENT_PASSWORD "ntr_cli_pass"
 
+// SD logging
+#define KEY_CONFIG_SD_LOG_ACTIVE "sd_log_active"
+
 // UART
 #define KEY_CONFIG_UART_NUM "uart_num"
 #define KEY_CONFIG_UART_TX_PIN "uart_tx_pin"

--- a/main/include/sd_logger.h
+++ b/main/include/sd_logger.h
@@ -1,0 +1,9 @@
+#ifndef ESP32_XBEE_SD_LOGGER_H
+#define ESP32_XBEE_SD_LOGGER_H
+
+#include <stddef.h>
+
+void sd_logger_init();
+void sd_logger_write(const void *data, size_t length);
+
+#endif //ESP32_XBEE_SD_LOGGER_H

--- a/main/interface/ntrip_server.c
+++ b/main/interface/ntrip_server.c
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "util.h"
 #include "uart.h"
+#include "sd_logger.h"
 
 static const char *TAG = "NTRIP_SERVER";
 
@@ -74,6 +75,7 @@ static void ntrip_server_uart_handler(void* handler_args, esp_event_base_t base,
         vTaskResume(server_task);
     } else {
         stream_stats_increment(stream_stats, 0, sent);
+        sd_logger_write(buffer, length);
     }
 }
 

--- a/main/interface/ntrip_server_2.c
+++ b/main/interface/ntrip_server_2.c
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "util.h"
 #include "uart.h"
+#include "sd_logger.h"
 
 static const char *TAG = "NTRIP_SERVER";
 
@@ -74,6 +75,7 @@ static void ntrip_server_uart_handler(void* handler_args, esp_event_base_t base,
         vTaskResume(server_task);
     } else {
         stream_stats_increment(stream_stats, 0, sent);
+        sd_logger_write(buffer, length);
     }
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -36,6 +36,7 @@
 
 #include "uart.h"
 #include "interface/ntrip.h"
+#include "sd_logger.h"
 #include "tasks.h"
 
 static const char *TAG = "MAIN";
@@ -126,6 +127,7 @@ void app_main()
 
     web_server_init();
 
+    sd_logger_init();
 
     ntrip_server_init();
     ntrip_server_2_init();

--- a/main/sd_logger.c
+++ b/main/sd_logger.c
@@ -1,0 +1,84 @@
+/*
+ * SD logger for RTCM data
+ * This file is part of the ESP32-XBee distribution (https://github.com/nebkat/esp32-xbee).
+ * Copyright (c) 2019 Nebojsa Cvetkovic.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+#include <esp_log.h>
+#include <esp_vfs_fat.h>
+#include <sdmmc_cmd.h>
+#include "sd_logger.h"
+#include "config.h"
+
+static const char *TAG = "SD_LOG";
+
+static FILE *log_file = NULL;
+static time_t day_start = 0;
+static bool sd_enabled = false;
+static sdmmc_card_t *card;
+
+static void open_log_file() {
+    time_t now;
+    time(&now);
+    struct tm tm_info;
+    localtime_r(&now, &tm_info);
+
+    struct tm day = tm_info;
+    day.tm_hour = day.tm_min = day.tm_sec = 0;
+    day_start = mktime(&day);
+
+    char path[64];
+    snprintf(path, sizeof(path), "/sdcard/%04d%02d%02d.rtcm",
+             tm_info.tm_year + 1900, tm_info.tm_mon + 1, tm_info.tm_mday);
+
+    log_file = fopen(path, "a");
+    if (!log_file) {
+        ESP_LOGE(TAG, "Could not open %s: %d %s", path, errno, strerror(errno));
+        sd_enabled = false;
+    }
+}
+
+void sd_logger_init() {
+    if (!config_get_bool1(CONF_ITEM(KEY_CONFIG_SD_LOG_ACTIVE))) return;
+
+    sdmmc_host_t host = SDSPI_HOST_DEFAULT();
+    sdspi_slot_config_t slot_config = SDSPI_SLOT_CONFIG_DEFAULT();
+    esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+            .format_if_mount_failed = false,
+            .max_files = 3
+    };
+
+    esp_err_t ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to mount SD card: %s", esp_err_to_name(ret));
+        return;
+    }
+
+    sd_enabled = true;
+    open_log_file();
+}
+
+void sd_logger_write(const void *data, size_t length) {
+    if (!sd_enabled || !log_file) return;
+
+    time_t now;
+    time(&now);
+    if (now - day_start >= 24 * 60 * 60) {
+        fclose(log_file);
+        open_log_file();
+        if (!sd_enabled) return;
+    }
+
+    size_t written = fwrite(data, 1, length, log_file);
+    if (written != length) {
+        ESP_LOGE(TAG, "Failed writing SD: %d %s", errno, strerror(errno));
+    }
+}


### PR DESCRIPTION
## Summary
- add configuration option `sd_log_active`
- implement SD logger with daily file rotation
- hook logger into NTRIP server handlers
- initialize logger from `app_main`
- add new files to build system

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d945b5d483258fb33e26e0c55313